### PR TITLE
Fix pi-stacking cutoff in distance filter

### DIFF
--- a/gpu_accelerated_flux.py
+++ b/gpu_accelerated_flux.py
@@ -164,7 +164,7 @@ class HierarchicalDistanceFilter:
             (3.5, ['hbond']),           # Stage 1: Very close
             (5.0, ['vdw', 'salt']),     # Stage 2: Medium
             (6.0, ['pi_cation']),       # Stage 3: Extended
-            (7.0, ['pi_stacking'])      # Stage 4: Long range
+            (4.5, ['pi_stacking'])      # Stage 4: Long range (see CHANGELOG 2025-01-06)
         ]
     
     def filter_pairs_hierarchical(self, coords1, coords2, interaction_detector):


### PR DESCRIPTION
## Summary
- keep HierarchicalDistanceFilter consistent with changelog
- document pi-stacking cutoff for regression prevention

## Testing
- `python -m py_compile gpu_accelerated_flux.py`


------
https://chatgpt.com/codex/tasks/task_e_683fa76596e0832f883e1189fcf5da0d