### PR TITLE
Enable approach distance option in UMA workflow

### DIFF
--- a/fluxmd/core/trajectory_generator_uma.py
+++ b/fluxmd/core/trajectory_generator_uma.py
@@ -25,6 +25,7 @@ def run_single_iteration_uma(self, iteration_num, protein_atoms_df, ligand_atoms
     
     Args:
         save_trajectories: If True, generate and save trajectory visualizations
+        approach_distance: Step size to advance ligand in Angstroms
     """
     print(f"\n{'='*60}")
     print(f"ITERATION {iteration_num + 1}")
@@ -106,8 +107,8 @@ def run_single_iteration_uma(self, iteration_num, protein_atoms_df, ligand_atoms
 # Add this new method to run complete UMA-optimized analysis:
 def run_complete_analysis_uma(self, protein_file, ligand_file, output_dir,
                              n_steps=200, n_iterations=10, n_approaches=10,
-                             starting_distance=20.0, n_rotations=36,
-                             use_gpu=True, physiological_pH=7.4,
+                             starting_distance=20.0, approach_distance=2.5,
+                             n_rotations=36, use_gpu=True, physiological_pH=7.4,
                              save_trajectories=False):
     """
     Orchestrates the entire analysis with UMA-optimized GPU workflow.
@@ -115,6 +116,7 @@ def run_complete_analysis_uma(self, protein_file, ligand_file, output_dir,
     
     Args:
         save_trajectories: If True, generate and save trajectory visualizations
+        approach_distance: Step size to advance ligand in Angstroms
     """
     print("\n" + "="*80)
     print("FLUXMD ANALYSIS - UNIFIED MEMORY ARCHITECTURE (UMA) OPTIMIZED")
@@ -191,6 +193,7 @@ def run_complete_analysis_uma(self, protein_file, ligand_file, output_dir,
             starting_distance, n_steps, n_approaches, n_rotations,
             output_dir, gpu_calc, approach_angles,
             ca_coords=ca_coords, ligand_mw=ligand_mw,
+            approach_distance=approach_distance,
             save_trajectories=save_trajectories
         )
         
@@ -286,7 +289,9 @@ def run_complete_analysis_uma(self, protein_file, ligand_file, output_dir,
         output_dir, protein_file, ligand_file,
         n_steps, n_iterations, n_approaches,
         starting_distance, n_rotations, physiological_pH,
-        device.type
+        device.type,
+        save_trajectories=save_trajectories,
+        approach_distance=approach_distance
     )
     
     print("\n" + "="*80)

--- a/fluxmd_uma.py
+++ b/fluxmd_uma.py
@@ -189,6 +189,8 @@ def main():
                        help='Number of iterations (default: 10)')
     parser.add_argument('-a', '--approaches', type=int, default=10,
                        help='Number of approach angles (default: 10)')
+    parser.add_argument('--approach-distance', dest='approach_distance', type=float, default=2.5,
+                       help='Distance advanced between approaches in Angstroms (default: 2.5)')
     parser.add_argument('-d', '--distance', type=float, default=20.0,
                        help='Starting distance in Angstroms (default: 20.0)')
     parser.add_argument('-r', '--rotations', type=int, default=36,
@@ -237,6 +239,8 @@ def main():
             args.approaches = loaded_params['n_approaches']
         if 'starting_distance' in loaded_params:
             args.distance = loaded_params['starting_distance']
+        if 'approach_distance' in loaded_params:
+            args.approach_distance = loaded_params['approach_distance']
         if 'n_rotations' in loaded_params:
             args.rotations = loaded_params['n_rotations']
         if 'physiological_pH' in loaded_params:
@@ -275,6 +279,7 @@ def main():
     print(f"  Steps: {args.steps}")
     print(f"  Iterations: {args.iterations}")
     print(f"  Approaches: {args.approaches}")
+    print(f"  Approach distance: {args.approach_distance} Angstroms")
     print(f"  Distance: {args.distance} Angstroms")
     print(f"  Rotations: {args.rotations}")
     print(f"  pH: {args.ph}")
@@ -335,6 +340,7 @@ def main():
         def capturing_run_complete(*args, **kwargs):
             # Add save_trajectories to kwargs from command-line args
             kwargs['save_trajectories'] = cmd_args.save_trajectories
+            kwargs['approach_distance'] = cmd_args.approach_distance
             
             # Call original method
             result = original_run_complete(*args, **kwargs)
@@ -352,6 +358,7 @@ def main():
             n_steps=args.steps,
             n_iterations=args.iterations,
             n_approaches=args.approaches,
+            approach_distance=args.approach_distance,
             starting_distance=args.distance,
             n_rotations=args.rotations,
             use_gpu=has_gpu,


### PR DESCRIPTION
## Summary
- add `--approach-distance` CLI argument in `fluxmd_uma.py`
- display approach distance when showing parameters
- forward approach distance to `run_complete_analysis_uma`
- pass argument through UMA analysis and save parameters

## Testing
- `pytest -q` *(fails: unrecognized arguments because pytest-cov is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68437d9103ac832f9937293054594e6a