### PR TITLE
Fix random walk stagnation

### DIFF
--- a/fluxmd/core/trajectory_generator.py
+++ b/fluxmd/core/trajectory_generator.py
@@ -920,9 +920,17 @@ class ProteinLigandFluxAnalyzer:
         
         return np.array(trajectory)
     
-    def generate_random_walk_trajectory(self, start_pos, n_steps, ligand_coords,
-                                      ligand_atoms, molecular_weight=300.0, dt=40,
-                                      max_distance=None):
+    def generate_random_walk_trajectory(
+        self,
+        start_pos,
+        n_steps,
+        ligand_coords,
+        ligand_atoms,
+        molecular_weight=300.0,
+        dt=40,
+        max_distance=None,
+        max_attempts=10,
+    ):
         """
         Generate a truly random Brownian walk with no directional bias.
         
@@ -967,28 +975,29 @@ class ProteinLigandFluxAnalyzer:
         n_rejected = 0
         
         for i in range(1, n_steps):
-            # Generate random displacement - TRUE Brownian motion
-            displacement = np.random.randn(3) * step_size
-            proposed_pos = current_pos + displacement
-            
-            # Optional: enforce maximum distance boundary
-            if max_distance is not None:
-                distance_from_center = np.linalg.norm(proposed_pos - protein_center)
-                if distance_from_center > max_distance:
-                    # Reflect off boundary
-                    direction = (proposed_pos - protein_center) / distance_from_center
-                    proposed_pos = protein_center + direction * (2 * max_distance - distance_from_center)
-            
-            # Check collision
-            test_coords = ligand_coords + (proposed_pos - ligand_coords.mean(axis=0))
-            
-            if not self.collision_detector.check_collision(test_coords, ligand_atoms):
-                current_pos = proposed_pos
-            else:
+            attempts = 0
+            while attempts < max_attempts:
+                displacement = np.random.randn(3) * step_size
+                proposed_pos = current_pos + displacement
+
+                if max_distance is not None:
+                    distance_from_center = np.linalg.norm(proposed_pos - protein_center)
+                    if distance_from_center > max_distance:
+                        direction = (proposed_pos - protein_center) / distance_from_center
+                        proposed_pos = protein_center + direction * (
+                            2 * max_distance - distance_from_center
+                        )
+
+                test_coords = ligand_coords + (proposed_pos - ligand_coords.mean(axis=0))
+                if not self.collision_detector.check_collision(test_coords, ligand_atoms):
+                    current_pos = proposed_pos
+                    break
+
+                attempts += 1
+
+            if attempts == max_attempts:
                 n_rejected += 1
-                # For true random walk, if collision occurs, stay in place
-                # (don't try smaller steps as that would bias the distribution)
-            
+
             trajectory.append(current_pos.copy())
         
         if n_rejected > 0:


### PR DESCRIPTION
## Summary
- handle collision retries in random walk
- add `max_attempts` parameter so Brownian motion doesn't freeze when collisions occur

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684abd19ca008326a68f0f61c8dcd65b