### PR TITLE
Add major/minor groove pseudo atoms

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ fluxmd-dna ATCGATCG -o dna_structure.pdb
 - B-DNA double helix with accurate geometry ([Olson et al., 1998](https://www.pnas.org/doi/10.1073/pnas.95.19.11163))
 - Complete atomic detail including sugar-phosphate backbone
 - CONECT records for all covalent bonds
+- Optional pseudo-atoms marking major and minor grooves with `--include-grooves`
 
 ## Technical Implementation
 


### PR DESCRIPTION
## Summary
- extend `DNABuilder` with approximate groove dimensions
- compute groove centre coordinates when building DNA
- optionally include major/minor grooves via CLI flag `--include-grooves`
- document the new CLI flag in the README

## Testing
- `pip install -q -r requirements.txt`
- `pip install -q pytest pytest-cov`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6853e627e44883268bda8e68a1de2e79