### PR TITLE
Fix CI missing dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ dependencies = [
     "seaborn>=0.12.0",
     "colorama>=0.4.6",
     "pyyaml>=6.0",
+    "scikit-image>=0.25",
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,6 @@ scipy>=1.7
 pandas>=1.3
 matplotlib>=3.4
 biopython>=1.79
+scikit-image>=0.25
 pytest>=6.2
 pytest-cov>=2.12


### PR DESCRIPTION
## Summary
- ensure marching cubes dependency present
- include `scikit-image` in `requirements.txt`
- add `scikit-image` to project dependencies

## Testing
- `pytest tests/test_ses_builder.py::test_build_ses0_requires_skimage -q`


------
https://chatgpt.com/codex/tasks/task_e_68581a5763948326b517dc3b0358faa8