### PR TITLE
Central RNG utilities and backend banner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 - docs/ARCHITECTURAL_REVIEW.md integrated in MkDocs.
 - Scaffold `build_hybrid_shell()` and placeholder test.
 - GPU-enabled Codex CI integration using CUDA-enabled PyTorch wheels.
+- Centralised RNG utilities and CLI backend banner.
+- Config parser now accepts `matroshika` as alias for `matryoshka`.
 
 ### Known Issues
 - 5 tests currently marked as expected failures (xfail); see issue tracker for details.

--- a/fluxmd.py
+++ b/fluxmd.py
@@ -104,6 +104,19 @@ def print_banner(text):
     print("=" * 80 + "\n")
 
 
+def print_backend_info(seed: int | None) -> None:
+    """Print computation backend, dtype and seed."""
+    try:
+        backend = get_device()
+    except Exception:
+        backend = "cpu"
+    print_banner("FLUXMD BACKEND")
+    print(f"Backend: {backend}")
+    print(f"Dtype: float64")
+    if seed is not None:
+        print(f"Seed: {seed}")
+
+
 def convert_cif_to_pdb(cif_file):
     """Convert CIF/mmCIF to PDB format using OpenBabel"""
     pdb_file = cif_file.rsplit(".", 1)[0] + ".pdb"
@@ -2201,6 +2214,7 @@ def run_batch_mode(config: dict):
             "viscosity": config.get("viscosity", 0.00089),
             "max_steps": config.get("max_steps", 1_000_000),
             "use_gpu": config.get("use_gpu", True),
+            "seed": config.get("seed"),
         }
 
         # Run Matryoshka workflow directly
@@ -2397,6 +2411,15 @@ Examples:
         help="Run in non-interactive mode (requires --config)",
     )
 
+    parser.add_argument("--seed", type=int, help="Random seed for reproducibility")
+    parser.add_argument("--steps", type=int, help="Number of simulation steps")
+    parser.add_argument("--out", type=str, help="Output directory override")
+    parser.add_argument(
+        "--print-backend",
+        action="store_true",
+        help="Print backend, dtype and seed information",
+    )
+
     return parser.parse_args()
 
 
@@ -2414,6 +2437,16 @@ def main():
         try:
             config = load_config(args.config)
             config["_config_file"] = args.config
+
+            # Override with CLI options
+            if args.seed is not None:
+                config["seed"] = args.seed
+            if args.steps is not None:
+                config["max_steps"] = args.steps
+            if args.out is not None:
+                config["output_dir"] = args.out
+            if args.print_backend:
+                print_backend_info(config.get("seed"))
 
             # Dry run mode
             if args.dry_run:

--- a/fluxmd/core/dynamics/brownian_roller.py
+++ b/fluxmd/core/dynamics/brownian_roller.py
@@ -7,6 +7,7 @@ from typing import Dict, Tuple
 import numpy as np
 from scipy.spatial import cKDTree
 
+from ...utils.rng import create_generator
 from ..surface.ses_builder import SurfaceMesh
 
 __all__ = ["BrownianSurfaceRoller", "quaternion_multiply"]
@@ -78,8 +79,10 @@ class BrownianSurfaceRoller:
         self.dt_fs = self._calculate_adaptive_timestep()
         self.dt_ps = self.dt_fs / 1000.0  # Convert to picoseconds
 
-        # Initialize RNG
-        self.rng = np.random.default_rng(kwargs.get("seed", None))
+        # Initialize RNG – prefer explicitly provided generator
+        self.rng = kwargs.get("rng")
+        if self.rng is None:
+            self.rng = create_generator(kwargs.get("seed", None))
 
         # Friction coefficients
         self.gamma_t = self.kT / self.D_t

--- a/fluxmd/core/matryoshka_generator.py
+++ b/fluxmd/core/matryoshka_generator.py
@@ -11,6 +11,7 @@ import numpy as np
 from tqdm import tqdm
 
 from ..utils.cpu import format_workers_info, parse_workers
+from ..utils.rng import create_generator
 from .dynamics.brownian_roller import BrownianSurfaceRoller
 from .dynamics.brownian_roller import quaternion_multiply as _quat_mul
 from .geometry.pca_anchors import extreme_calpha_pairs
@@ -40,6 +41,9 @@ class MatryoshkaTrajectoryGenerator:
         self.protein_atoms = protein_atoms
         self.ligand_atoms = ligand_atoms
         self.params = params
+
+        # Central random generator for the whole workflow
+        self.rng = params.get("rng", create_generator(params.get("seed", None)))
 
         # Extract parameters with defaults
         self.temperature = params.get("T", 298.15)
@@ -288,11 +292,11 @@ class MatryoshkaTrajectoryGenerator:
         # Generate small rotations
         for i in range(1, n_variants):
             # Random small rotation axis
-            axis = np.random.randn(3)
+            axis = self.rng.normal(size=3)
             axis /= np.linalg.norm(axis)
 
             # Small angle (5-15 degrees)
-            angle = np.random.uniform(5, 15) * np.pi / 180
+            angle = self.rng.uniform(5, 15) * np.pi / 180
 
             # Create rotation quaternion
             half_angle = angle / 2
@@ -330,7 +334,7 @@ class MatryoshkaTrajectoryGenerator:
         # Subsample protein atoms for speed
         n_protein = len(self.protein_atoms["coords"])
         n_sample = max(100, int(n_protein * sample_fraction))
-        sample_indices = np.random.choice(n_protein, n_sample, replace=False)
+        sample_indices = self.rng.choice(n_protein, n_sample, replace=False)
 
         protein_coords_sample = self.protein_atoms["coords"][sample_indices]
         protein_names_sample = self.protein_atoms["names"][sample_indices]
@@ -369,9 +373,10 @@ class MatryoshkaTrajectoryGenerator:
         # Get the appropriate surface layer
         surface = self.layer_generator.get_layer(layer_idx)
 
-        # Create roller with unique seed
+        # Create roller with unique seed using central RNG
         if seed is None:
-            seed = hash((layer_idx, iteration_idx, time.time())) % 2**32
+            seed = int(self.rng.integers(0, 2**32))
+        roller_rng = create_generator(seed)
 
         # Create energy calculator function for layer hopping
         def energy_calculator(pos, quat, layer):
@@ -395,7 +400,7 @@ class MatryoshkaTrajectoryGenerator:
             hop_probability=0.1,
             groove_detector=self.ses_builder.groove_detector,
             groove_preference=self.params.get("groove_preference", "major"),
-            seed=seed,
+            rng=roller_rng,
         )
 
         # Run trajectory
@@ -571,8 +576,9 @@ class MatryoshkaTrajectoryGenerator:
                         if layer_idx == start_layer and iteration_idx < start_iteration:
                             continue
 
-                        # Generate seed for reproducibility
-                        seed = hash((layer_idx, iteration_idx, 42)) % 2**32
+                        # Generate seed for reproducibility based on user seed
+                        base_seed = self.params.get("seed", 0)
+                        seed = hash((layer_idx, iteration_idx, base_seed)) % 2**32
 
                         # Run trajectory
                         trajectory = self._run_single_trajectory(layer_idx, iteration_idx, seed)
@@ -620,7 +626,8 @@ class MatryoshkaTrajectoryGenerator:
                 if layer_idx == start_layer and iteration_idx < start_iteration:
                     continue
 
-                seed = hash((layer_idx, iteration_idx, 42)) % 2**32
+                base_seed = self.params.get("seed", 0)
+                seed = hash((layer_idx, iteration_idx, base_seed)) % 2**32
                 work_queue.put((layer_idx, iteration_idx, seed))
                 n_items += 1
 

--- a/fluxmd/utils/__init__.py
+++ b/fluxmd/utils/__init__.py
@@ -12,6 +12,7 @@ from .config_parser import create_example_config, load_config, print_derived_con
 from .cpu import format_workers_info, get_optimal_workers, parse_workers
 from .dna_to_pdb import DNABuilder
 from .pdb_parser import PDBParser
+from .rng import create_generator
 
 __all__ = [
     "DNABuilder",
@@ -22,4 +23,5 @@ __all__ = [
     "load_config",
     "print_derived_constants",
     "create_example_config",
+    "create_generator",
 ]

--- a/fluxmd/utils/config_parser.py
+++ b/fluxmd/utils/config_parser.py
@@ -37,6 +37,10 @@ def load_config(config_path: str) -> Dict[str, Any]:
         else:
             raise ValueError(f"Unsupported config format: {config_path.suffix}")
 
+    # Normalise legacy mode names
+    if config.get("mode") == "matroshika":
+        config["mode"] = "matryoshka"
+
     # Validate configuration
     validate_config(config)
 

--- a/fluxmd/utils/rng.py
+++ b/fluxmd/utils/rng.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+"""Central random number generation utilities.
+
+Provides a simple factory for NumPy ``Generator`` instances so that all
+components share consistent seeding behaviour.  Modules should request a
+Generator explicitly rather than relying on ``np.random``'s global state.
+"""
+
+from typing import Optional
+
+import numpy as np
+
+__all__ = ["create_generator"]
+
+
+def create_generator(seed: Optional[int] = None) -> np.random.Generator:
+    """Return a new NumPy ``Generator`` with the given ``seed``.
+
+    Parameters
+    ----------
+    seed:
+        Seed for the generator.  ``None`` uses NumPy's default seeding
+        mechanism.
+    """
+
+    return np.random.default_rng(seed)

--- a/tests/matryoshka/test_cli_banner.py
+++ b/tests/matryoshka/test_cli_banner.py
@@ -1,0 +1,43 @@
+import pathlib
+import subprocess
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[2]))
+
+
+def run_cli(config_path):
+    # Use the script entry point directly since the package lacks __main__
+    script = pathlib.Path(__file__).resolve().parents[2] / "fluxmd.py"
+    cmd = [
+        sys.executable,
+        str(script),
+        "--config",
+        str(config_path),
+        "--dry-run",
+        "--seed",
+        "5",
+        "--print-backend",
+    ]
+    completed = subprocess.run(cmd, capture_output=True, text=True, check=True)
+    return completed.stdout
+
+
+def test_cli_backend_banner(tmp_path):
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text(
+        """
+mode: matryoshka
+protein_file: protein.pdb
+ligand_file: ligand.sdf
+n_layers: 1
+n_trajectories_per_layer: 1
+layer_step: 1.5
+probe_radius: 0.75
+k_surf: 2.0
+k_guid: 0.5
+"""
+    )
+    out = run_cli(cfg)
+    assert "Backend:" in out
+    assert "Dtype:" in out
+    assert "Seed: 5" in out

--- a/tests/matryoshka/test_config_alias.py
+++ b/tests/matryoshka/test_config_alias.py
@@ -1,0 +1,25 @@
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[2]))
+
+from fluxmd.utils.config_parser import load_config
+
+
+def test_matroshika_alias(tmp_path):
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text(
+        """
+mode: matroshika
+protein_file: protein.pdb
+ligand_file: ligand.sdf
+n_layers: 1
+n_trajectories_per_layer: 1
+layer_step: 1.5
+probe_radius: 0.75
+k_surf: 2.0
+k_guid: 0.5
+"""
+    )
+    config = load_config(str(cfg))
+    assert config["mode"] == "matryoshka"


### PR DESCRIPTION
## Summary
- add shared RNG generator and expose through utils
- allow legacy `matroshika` mode name and seed CLI override
- print backend, dtype and seed when requested

## Testing
- `pre-commit run --files CHANGELOG.md fluxmd.py fluxmd/core/dynamics/brownian_roller.py fluxmd/core/matryoshka_generator.py fluxmd/utils/__init__.py fluxmd/utils/config_parser.py fluxmd/utils/rng.py tests/matryoshka/test_config_alias.py tests/matryoshka/test_cli_banner.py`
- `pytest -q tests/matryoshka`


------
https://chatgpt.com/codex/tasks/task_e_6895192bae2883269d553e3515929531